### PR TITLE
Add Phase 5: multi-agent review mode

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -27,6 +27,9 @@ export async function runCommand(options: CLIOptions): Promise<void> {
   console.log(chalk.gray(`  Workflow: ${plan.workflow.name}`));
   console.log(chalk.gray(`  Agent:    ${plan.agent.type}`));
   console.log(chalk.gray(`  Image:    ${plan.container.image}`));
+  if (plan.orchestration.mode === "review") {
+    console.log(chalk.gray(`  Mode:     review (max ${plan.orchestration.review.maxRounds} rounds)`));
+  }
   console.log();
 
   // --- Pre-flight ---
@@ -66,6 +69,14 @@ export async function runCommand(options: CLIOptions): Promise<void> {
     for (const step of result.validation.stepResults) {
       const icon = step.passed ? chalk.green("✔") : chalk.red("✗");
       console.log(chalk.gray(`    ${icon} ${step.name} (${step.attempts} attempt(s))`));
+    }
+  }
+
+  if (result.review) {
+    if (result.review.approved) {
+      console.log(chalk.gray(`  Review: ${result.review.totalRounds} round(s), approved on round ${result.review.approvedOnRound}`));
+    } else {
+      console.log(chalk.gray(`  Review: ${result.review.totalRounds} round(s), not approved`));
     }
   }
 
@@ -129,7 +140,7 @@ function printDryRun(plan: ReturnType<typeof resolveRunPlan>): void {
   for (const step of plan.validation.steps) {
     console.log(`    - ${step.name}: \`${step.command}\` (${step.retries} retries)`);
   }
-  console.log(`  Review:     ${plan.orchestration.review.enabled ? "enabled" : "disabled"}`);
+  console.log(`  Review:     ${plan.orchestration.review.enabled ? `enabled (max ${plan.orchestration.review.maxRounds} rounds)` : "disabled"}`);
   console.log(`  Timeout:    ${plan.agent.timeout}ms`);
   console.log();
 }

--- a/src/orchestration/modes.ts
+++ b/src/orchestration/modes.ts
@@ -2,10 +2,10 @@ import type { RunPlan } from "../workflow/types.js";
 import type { Logger } from "../logging/logger.js";
 import type { ExecutionResult } from "./single.js";
 import { executeSingleAgent } from "./single.js";
+import { executeReviewMode } from "./review.js";
 
 /**
  * Dispatch execution based on orchestration mode.
- * Phase 3 only implements "single". Review and parallel are Phase 5.
  */
 export async function executeRun(
   plan: RunPlan,
@@ -16,8 +16,7 @@ export async function executeRun(
     case "single":
       return executeSingleAgent(plan, logger, noCleanup);
     case "review":
-      logger.warn("orchestration", "Review mode not yet implemented, running as single agent");
-      return executeSingleAgent(plan, logger, noCleanup);
+      return executeReviewMode(plan, logger, noCleanup);
     case "parallel":
       logger.warn("orchestration", "Parallel mode not yet implemented, running as single agent");
       return executeSingleAgent(plan, logger, noCleanup);

--- a/src/orchestration/review.ts
+++ b/src/orchestration/review.ts
@@ -1,0 +1,329 @@
+import type Docker from "dockerode";
+import type { RunPlan } from "../workflow/types.js";
+import type { Logger } from "../logging/logger.js";
+import type { ExecutionResult } from "./single.js";
+import { prepareExecution } from "./single.js";
+import { getAgentAdapter } from "../agent/registry.js";
+import { invokeAgent } from "../agent/invoke.js";
+import { buildPrompt } from "../context/prompt.js";
+import { createContainer, destroyContainer } from "../container/runner.js";
+import { getClaudeAuth } from "../auth/claude.js";
+import { getCodexAuth } from "../auth/codex.js";
+import { prepareClaudeMounts, prepareCodexMounts } from "../auth/mount.js";
+import { runValidationLoop } from "../validation/runner.js";
+import { collectOutput } from "../output/collector.js";
+import { cleanupRun, type CleanupContext } from "../container/cleanup.js";
+import { Timer } from "../utils/timer.js";
+import { emitRunEvent } from "../logging/events.js";
+
+export interface ReviewResult {
+  approved: boolean;
+  feedback: string;
+}
+
+export function buildReviewPrompt(plan: RunPlan, round: number): string {
+  const parts: string[] = [];
+
+  // 1. Reviewer system prompt (from workflow definition)
+  parts.push(plan.orchestration.review.system);
+
+  // 2. Context about the task
+  parts.push(`\n--- Original Task ---\n${plan.task}\n`);
+
+  // 3. Instructions
+  if (plan.output.mode === "git") {
+    parts.push(`The implementer's changes are in this workspace. Run \`git diff HEAD~1\` to see the changes.`);
+  } else {
+    parts.push(`The implementer's output files are in ${plan.output.path}. Review their contents.`);
+  }
+
+  parts.push(`\nThis is review round ${round}. If the output is acceptable, respond with exactly: LGTM`);
+  parts.push(`If there are issues, list them numbered. Be specific and actionable.`);
+
+  return parts.join("\n");
+}
+
+export function parseReviewResult(stdout: string): ReviewResult {
+  const trimmed = stdout.trim();
+  const lastLines = trimmed.split("\n").slice(-5).join("\n").trim();
+
+  // Check for approval markers (case-insensitive)
+  const approved = /\b(LGTM|APPROVED)\b/i.test(lastLines);
+
+  return {
+    approved,
+    feedback: approved ? "" : trimmed,
+  };
+}
+
+export function buildFixPrompt(reviewFeedback: string, round: number): string {
+  return [
+    `REVIEW FEEDBACK (round ${round}):`,
+    "",
+    reviewFeedback,
+    "",
+    "Fix all issues listed above. The reviewer will check again after you're done.",
+  ].join("\n");
+}
+
+/**
+ * Copy the workspace from the implementer container to the reviewer container
+ * using Docker's getArchive/putArchive (tar streaming).
+ */
+async function snapshotWorkspace(
+  sourceContainer: Docker.Container,
+  targetContainer: Docker.Container,
+  sourcePath: string,
+): Promise<void> {
+  const archive = await sourceContainer.getArchive({ path: sourcePath });
+  await targetContainer.putArchive(archive, { path: "/" });
+}
+
+/**
+ * Prepare credentials and mounts for the reviewer container.
+ */
+async function prepareReviewerCredentials(
+  agentType: string,
+  runId: string,
+  round: number,
+  cleanup: CleanupContext,
+): Promise<{ binds: string[]; agentEnv: string[] }> {
+  const binds: string[] = [];
+  const agentEnv: string[] = [];
+
+  if (agentType === "claude-code") {
+    const auth = await getClaudeAuth();
+    if (!auth) throw new Error("No Claude Code credentials configured for reviewer");
+    const mounts = prepareClaudeMounts(auth, `${runId}-reviewer-${round}`);
+    binds.push(...mounts.binds);
+    cleanup.secretCleanups.push(mounts.cleanup);
+    if (auth.type === "api_key" && auth.apiKey) {
+      agentEnv.push(`ANTHROPIC_API_KEY=${auth.apiKey}`);
+    }
+    agentEnv.push("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1");
+  } else {
+    const apiKey = await getCodexAuth();
+    if (!apiKey) throw new Error("No Codex credentials configured for reviewer");
+    const mounts = prepareCodexMounts(apiKey, `${runId}-reviewer-${round}`);
+    binds.push(...mounts.binds);
+    cleanup.secretCleanups.push(mounts.cleanup);
+    agentEnv.push(`OPENAI_API_KEY=${apiKey}`);
+  }
+
+  return { binds, agentEnv };
+}
+
+export async function executeReviewMode(
+  plan: RunPlan,
+  logger: Logger,
+  noCleanup = false
+): Promise<ExecutionResult> {
+  const timer = new Timer();
+  const cleanup: CleanupContext = { tempDirs: [], secretCleanups: [] };
+  const reviewerCleanup: CleanupContext = { tempDirs: [], secretCleanups: [] };
+
+  try {
+    // --- Phase: Prepare (implementer) ---
+    const { container, adapter, agentOptions, agentEnv, resolvedImage } =
+      await prepareExecution(plan, logger, cleanup);
+
+    // --- Phase: Execute ---
+    emitRunEvent({ runId: plan.runId, type: "phase", timestamp: new Date().toISOString(), data: { phase: "execute" } });
+
+    const prompt = buildPrompt(plan);
+    logger.info("agent", `Running ${plan.agent.type}...`);
+    const agentResult = await invokeAgent(container, adapter, prompt, agentOptions, agentEnv);
+
+    logger.info("agent", `Agent finished (exit ${agentResult.exitCode}, ${agentResult.durationMs}ms)`);
+    if (agentResult.exitCode !== 0) {
+      logger.warn("agent", `Agent exited with non-zero code: ${agentResult.exitCode}`);
+      if (agentResult.stderr) {
+        logger.debug("agent", `stderr: ${agentResult.stderr.slice(0, 500)}`);
+      }
+    }
+
+    // --- Phase: Validate ---
+    emitRunEvent({ runId: plan.runId, type: "phase", timestamp: new Date().toISOString(), data: { phase: "validate" } });
+
+    logger.info("validate", `Running ${plan.validation.steps.length} validation steps...`);
+    let validationResult = await runValidationLoop(
+      container, plan, adapter, agentOptions, agentEnv, logger
+    );
+
+    if (!validationResult.passed && plan.validation.onFailure === "abandon") {
+      emitRunEvent({ runId: plan.runId, type: "failed", timestamp: new Date().toISOString(), data: { reason: "validation_failed" } });
+      return {
+        success: false,
+        validation: validationResult,
+        durationMs: timer.elapsed(),
+        error: "Validation failed and on_failure is set to 'abandon'",
+      };
+    }
+
+    // --- Phase: Review ---
+    emitRunEvent({ runId: plan.runId, type: "phase", timestamp: new Date().toISOString(), data: { phase: "review" } });
+
+    const maxRounds = plan.orchestration.review.maxRounds;
+    const reviewAgent = plan.orchestration.review.agent;
+    const reviewModel = plan.orchestration.review.model;
+    const reviewAdapter = getAgentAdapter(reviewAgent);
+
+    // Build a resolved plan for reviewer containers (same image as implementer)
+    const resolvedPlan = { ...plan, container: { ...plan.container, image: resolvedImage } };
+
+    const reviewOptions = {
+      model: reviewModel,
+      maxTurns: plan.agent.maxTurns,
+      timeout: plan.agent.timeout,
+      flags: plan.agent.flags,
+      workingDir: plan.input.mountPath,
+    };
+
+    let approvedOnRound: number | undefined;
+
+    for (let round = 1; round <= maxRounds; round++) {
+      logger.info("review", `Starting review round ${round}/${maxRounds}...`);
+
+      // Prepare reviewer credentials
+      const reviewerCreds = await prepareReviewerCredentials(
+        reviewAgent, plan.runId, round, reviewerCleanup
+      );
+
+      // Create reviewer container
+      logger.info("review", "Launching reviewer container...");
+      const reviewerContainer = await createContainer(resolvedPlan, reviewerCreds.binds);
+      reviewerCleanup.container = reviewerContainer;
+
+      // Snapshot workspace from implementer to reviewer
+      await snapshotWorkspace(container, reviewerContainer, plan.input.mountPath);
+
+      // Build and invoke reviewer
+      const reviewPrompt = buildReviewPrompt(plan, round);
+
+      logger.info("review", "Reviewer running...");
+      const reviewExecResult = await invokeAgent(
+        reviewerContainer, reviewAdapter, reviewPrompt, reviewOptions,
+        reviewerCreds.agentEnv, `review-${round}`
+      );
+
+      // Parse review result
+      const parsed = parseReviewResult(reviewExecResult.stdout);
+
+      // Destroy reviewer container for this round
+      await destroyContainer(reviewerContainer);
+      reviewerCleanup.container = undefined;
+
+      if (parsed.approved) {
+        logger.info("review", `✔ Review round ${round}: APPROVED`);
+        approvedOnRound = round;
+        break;
+      }
+
+      logger.warn("review", `✗ Review round ${round}: issues found`);
+
+      if (round < maxRounds) {
+        // Feed issues back to implementer
+        logger.info("review", "Feeding issues to implementer...");
+        const fixPrompt = buildFixPrompt(parsed.feedback, round);
+
+        logger.info("agent", "Agent fixing review issues...");
+        await invokeAgent(
+          container, adapter, fixPrompt, agentOptions, agentEnv, `review-fix-${round}`
+        );
+
+        // Re-validate after fix
+        if (plan.validation.steps.length > 0) {
+          logger.info("validate", "Re-validating after review fix...");
+          validationResult = await runValidationLoop(
+            container, plan, adapter, agentOptions, agentEnv, logger
+          );
+
+          if (!validationResult.passed && plan.validation.onFailure === "abandon") {
+            emitRunEvent({
+              runId: plan.runId, type: "failed", timestamp: new Date().toISOString(),
+              data: { reason: "validation_failed_during_review" },
+            });
+            return {
+              success: false,
+              validation: validationResult,
+              durationMs: timer.elapsed(),
+              error: "Validation failed during review fix cycle",
+              review: { totalRounds: round, approved: false },
+            };
+          }
+        }
+      }
+    }
+
+    // --- Phase: Collect Output ---
+    const approved = approvedOnRound !== undefined;
+
+    if (approved || validationResult.passed || plan.validation.onFailure === "output-wip") {
+      emitRunEvent({ runId: plan.runId, type: "phase", timestamp: new Date().toISOString(), data: { phase: "output" } });
+
+      logger.info("output", `Collecting ${plan.output.mode} output...`);
+      const output = await collectOutput(container, plan, logger);
+
+      emitRunEvent({
+        runId: plan.runId,
+        type: "completed",
+        timestamp: new Date().toISOString(),
+        data: { success: approved, output },
+      });
+
+      return {
+        success: approved,
+        output,
+        validation: validationResult,
+        durationMs: timer.elapsed(),
+        review: {
+          totalRounds: approvedOnRound ?? maxRounds,
+          approved,
+          approvedOnRound,
+        },
+      };
+    }
+
+    // Review not approved after max rounds
+    emitRunEvent({
+      runId: plan.runId,
+      type: "failed",
+      timestamp: new Date().toISOString(),
+      data: { reason: "review_not_approved" },
+    });
+
+    return {
+      success: false,
+      validation: validationResult,
+      durationMs: timer.elapsed(),
+      error: `Review not approved after ${maxRounds} rounds`,
+      review: { totalRounds: maxRounds, approved: false },
+    };
+
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error("execution", message);
+    emitRunEvent({
+      runId: plan.runId,
+      type: "failed",
+      timestamp: new Date().toISOString(),
+      data: { error: message },
+    });
+    return {
+      success: false,
+      validation: { passed: false, totalAttempts: 0, stepResults: [] },
+      durationMs: timer.elapsed(),
+      error: message,
+    };
+  } finally {
+    // Always clean up reviewer resources
+    await cleanupRun(reviewerCleanup);
+
+    if (!noCleanup) {
+      logger.info("cleanup", "Cleaning up...");
+      await cleanupRun(cleanup);
+    } else {
+      logger.info("cleanup", "Skipping cleanup (--no-cleanup)");
+    }
+  }
+}

--- a/src/orchestration/single.ts
+++ b/src/orchestration/single.ts
@@ -11,12 +11,18 @@ import { prepareRepoWorkspace, prepareFilesWorkspace } from "../container/worksp
 import { createIsolatedNetwork, applyFirewall } from "../container/network.js";
 import { getClaudeAuth } from "../auth/claude.js";
 import { getCodexAuth } from "../auth/codex.js";
-import { prepareClaudeMounts, prepareCodexMounts, type ContainerMounts } from "../auth/mount.js";
+import { prepareClaudeMounts, prepareCodexMounts } from "../auth/mount.js";
 import { runValidationLoop } from "../validation/runner.js";
 import { collectOutput } from "../output/collector.js";
 import { cleanupRun, type CleanupContext } from "../container/cleanup.js";
 import { Timer } from "../utils/timer.js";
 import { emitRunEvent } from "../logging/events.js";
+
+export interface ReviewSummary {
+  totalRounds: number;
+  approved: boolean;
+  approvedOnRound?: number;
+}
 
 export interface ExecutionResult {
   success: boolean;
@@ -24,6 +30,94 @@ export interface ExecutionResult {
   validation: ValidationResult;
   durationMs: number;
   error?: string;
+  review?: ReviewSummary;
+}
+
+/**
+ * Shared prepare phase: ensure image, prepare workspace, credentials,
+ * network, create container, apply firewall.
+ *
+ * The caller owns the `cleanup` context — resources are added to it
+ * progressively so cleanup works even if this function throws partway through.
+ */
+export async function prepareExecution(
+  plan: RunPlan,
+  logger: Logger,
+  cleanup: CleanupContext,
+) {
+  emitRunEvent({ runId: plan.runId, type: "phase", timestamp: new Date().toISOString(), data: { phase: "prepare" } });
+
+  // 1. Ensure Docker image exists
+  logger.info("prepare", `Ensuring image: ${plan.container.image}`);
+  const resolvedImage = await ensureImage(plan.container.image, plan.container.dockerfile);
+
+  // 2. Prepare workspace
+  const binds: string[] = [];
+  if (plan.input.mode === "repo") {
+    logger.info("prepare", "Preparing repo workspace...");
+    const workspaceDir = prepareRepoWorkspace(plan.input.sources[0], plan.input.exclude);
+    cleanup.tempDirs.push(workspaceDir);
+    binds.push(`${workspaceDir}:${plan.input.mountPath}`);
+  } else {
+    logger.info("prepare", "Preparing file workspace...");
+    const { inputDir, outputDir } = prepareFilesWorkspace(plan.input.sources);
+    cleanup.tempDirs.push(inputDir, outputDir);
+    binds.push(`${inputDir}:${plan.input.mountPath}:ro`);
+    binds.push(`${outputDir}:${plan.output.path}`);
+  }
+
+  // 3. Prepare credentials and build direct env vars (no shell subcommands)
+  const agentEnv: string[] = [];
+
+  if (plan.agent.type === "claude-code") {
+    const auth = await getClaudeAuth();
+    if (!auth) throw new Error("No Claude Code credentials configured");
+    const mounts = prepareClaudeMounts(auth, plan.runId);
+    binds.push(...mounts.binds);
+    cleanup.secretCleanups.push(mounts.cleanup);
+    if (auth.type === "api_key" && auth.apiKey) {
+      agentEnv.push(`ANTHROPIC_API_KEY=${auth.apiKey}`);
+    }
+    agentEnv.push("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1");
+  } else {
+    const apiKey = await getCodexAuth();
+    if (!apiKey) throw new Error("No Codex credentials configured");
+    const mounts = prepareCodexMounts(apiKey, plan.runId);
+    binds.push(...mounts.binds);
+    cleanup.secretCleanups.push(mounts.cleanup);
+    agentEnv.push(`OPENAI_API_KEY=${apiKey}`);
+  }
+
+  // 4. Create network (only for allowlist mode)
+  if (plan.container.network.mode === "allowlist") {
+    logger.info("prepare", "Creating isolated network...");
+    await createIsolatedNetwork(plan.container.network.dockerNetwork);
+    cleanup.networkName = plan.container.network.dockerNetwork;
+  }
+
+  // 5. Create container with resolved image
+  logger.info("prepare", "Starting container...");
+  const resolvedPlan = { ...plan, container: { ...plan.container, image: resolvedImage } };
+  const container = await createContainer(resolvedPlan, binds);
+  cleanup.container = container;
+
+  // 6. Apply firewall (only for allowlist mode)
+  if (plan.container.network.mode === "allowlist" && plan.container.network.allow) {
+    logger.info("prepare", "Applying network firewall...");
+    await applyFirewall(container, plan.container.network.allow);
+  }
+
+  // Build adapter and options
+  const adapter = getAgentAdapter(plan.agent.type);
+  const agentOptions = {
+    model: plan.agent.model,
+    maxTurns: plan.agent.maxTurns,
+    timeout: plan.agent.timeout,
+    flags: plan.agent.flags,
+    workingDir: plan.input.mountPath,
+  };
+
+  return { container, adapter, agentOptions, agentEnv, resolvedImage };
 }
 
 export async function executeSingleAgent(
@@ -36,83 +130,12 @@ export async function executeSingleAgent(
 
   try {
     // --- Phase: Prepare ---
-    emitRunEvent({ runId: plan.runId, type: "phase", timestamp: new Date().toISOString(), data: { phase: "prepare" } });
-
-    // 1. Ensure Docker image exists
-    logger.info("prepare", `Ensuring image: ${plan.container.image}`);
-    const image = await ensureImage(plan.container.image, plan.container.dockerfile);
-
-    // 2. Prepare workspace
-    const binds: string[] = [];
-    if (plan.input.mode === "repo") {
-      logger.info("prepare", "Preparing repo workspace...");
-      const workspaceDir = prepareRepoWorkspace(plan.input.sources[0], plan.input.exclude);
-      cleanup.tempDirs.push(workspaceDir);
-      binds.push(`${workspaceDir}:${plan.input.mountPath}`);
-    } else {
-      logger.info("prepare", "Preparing file workspace...");
-      const { inputDir, outputDir } = prepareFilesWorkspace(plan.input.sources);
-      cleanup.tempDirs.push(inputDir, outputDir);
-      binds.push(`${inputDir}:${plan.input.mountPath}:ro`);
-      binds.push(`${outputDir}:${plan.output.path}`);
-    }
-
-    // 3. Prepare credentials and build direct env vars (no shell subcommands)
-    let mounts: ContainerMounts;
-    let agentEnv: string[] = [];
-
-    if (plan.agent.type === "claude-code") {
-      const auth = await getClaudeAuth();
-      if (!auth) throw new Error("No Claude Code credentials configured");
-      mounts = prepareClaudeMounts(auth, plan.runId);
-      // Build direct env vars — read actual key, no shell subcommands
-      if (auth.type === "api_key" && auth.apiKey) {
-        agentEnv.push(`ANTHROPIC_API_KEY=${auth.apiKey}`);
-      }
-      agentEnv.push("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1");
-    } else {
-      const apiKey = await getCodexAuth();
-      if (!apiKey) throw new Error("No Codex credentials configured");
-      mounts = prepareCodexMounts(apiKey, plan.runId);
-      agentEnv.push(`OPENAI_API_KEY=${apiKey}`);
-    }
-
-    binds.push(...mounts.binds);
-    cleanup.secretCleanups.push(mounts.cleanup);
-
-    // 4. Create network (only for allowlist mode)
-    if (plan.container.network.mode === "allowlist") {
-      logger.info("prepare", "Creating isolated network...");
-      await createIsolatedNetwork(plan.container.network.dockerNetwork);
-      cleanup.networkName = plan.container.network.dockerNetwork;
-    }
-
-    // 5. Create container with resolved image
-    logger.info("prepare", "Starting container...");
-    const resolvedPlan = { ...plan, container: { ...plan.container, image } };
-    const container = await createContainer(resolvedPlan, binds);
-    cleanup.container = container;
-
-    // 6. Apply firewall (only for allowlist mode)
-    if (plan.container.network.mode === "allowlist" && plan.container.network.allow) {
-      logger.info("prepare", "Applying network firewall...");
-      await applyFirewall(container, plan.container.network.allow);
-    }
+    const { container, adapter, agentOptions, agentEnv } = await prepareExecution(plan, logger, cleanup);
 
     // --- Phase: Execute ---
     emitRunEvent({ runId: plan.runId, type: "phase", timestamp: new Date().toISOString(), data: { phase: "execute" } });
 
-    // 7. Build prompt and invoke agent via temp file (avoids ARG_MAX / escaping issues)
     const prompt = buildPrompt(plan);
-    const adapter = getAgentAdapter(plan.agent.type);
-    const agentOptions = {
-      model: plan.agent.model,
-      maxTurns: plan.agent.maxTurns,
-      timeout: plan.agent.timeout,
-      flags: plan.agent.flags,
-      workingDir: plan.input.mountPath,
-    };
-
     logger.info("agent", `Running ${plan.agent.type}...`);
     const agentResult = await invokeAgent(
       container, adapter, prompt, agentOptions, agentEnv

--- a/test/unit/review-integration.test.ts
+++ b/test/unit/review-integration.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { RunPlan } from "../../src/workflow/types.js";
+
+// --- Hoisted mocks ---
+const mocks = vi.hoisted(() => {
+  const implementerContainer = {
+    getArchive: vi.fn().mockResolvedValue(Buffer.from("fake-tar")),
+    putArchive: vi.fn().mockResolvedValue(undefined),
+  };
+  return { implementerContainer };
+});
+
+// Mock prepareExecution (shared prepare phase from single.ts)
+vi.mock("../../src/orchestration/single.js", () => ({
+  prepareExecution: vi.fn().mockResolvedValue({
+    container: mocks.implementerContainer,
+    adapter: { name: "claude-code", buildShellCommand: vi.fn().mockReturnValue("echo test") },
+    agentOptions: { model: "", maxTurns: 50, timeout: 30000, flags: [], workingDir: "/workspace" },
+    agentEnv: [],
+    resolvedImage: "forgectl/code-node20",
+  }),
+}));
+
+vi.mock("../../src/agent/invoke.js", () => ({
+  invokeAgent: vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "", durationMs: 1000 }),
+}));
+
+vi.mock("../../src/context/prompt.js", () => ({
+  buildPrompt: vi.fn().mockReturnValue("test prompt"),
+}));
+
+vi.mock("../../src/container/runner.js", () => ({
+  createContainer: vi.fn().mockResolvedValue({
+    putArchive: vi.fn().mockResolvedValue(undefined),
+  }),
+  destroyContainer: vi.fn().mockResolvedValue(undefined),
+  execInContainer: vi.fn(),
+}));
+
+vi.mock("../../src/agent/registry.js", () => ({
+  getAgentAdapter: vi.fn().mockReturnValue({
+    name: "claude-code",
+    buildShellCommand: vi.fn().mockReturnValue("echo test"),
+  }),
+}));
+
+vi.mock("../../src/auth/claude.js", () => ({
+  getClaudeAuth: vi.fn().mockResolvedValue({ type: "api_key", apiKey: "test-key" }),
+}));
+
+vi.mock("../../src/auth/codex.js", () => ({
+  getCodexAuth: vi.fn().mockResolvedValue("test-openai-key"),
+}));
+
+vi.mock("../../src/auth/mount.js", () => ({
+  prepareClaudeMounts: vi.fn().mockReturnValue({ binds: [], env: {}, cleanup: vi.fn() }),
+  prepareCodexMounts: vi.fn().mockReturnValue({ binds: [], env: {}, cleanup: vi.fn() }),
+}));
+
+vi.mock("../../src/validation/runner.js", () => ({
+  runValidationLoop: vi.fn().mockResolvedValue({ passed: true, totalAttempts: 1, stepResults: [] }),
+}));
+
+vi.mock("../../src/output/collector.js", () => ({
+  collectOutput: vi.fn().mockResolvedValue({
+    mode: "git",
+    branch: "forge/test",
+    sha: "abc123",
+    filesChanged: 3,
+    insertions: 50,
+    deletions: 10,
+  }),
+}));
+
+vi.mock("../../src/container/cleanup.js", () => ({
+  cleanupRun: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/logging/events.js", () => ({
+  emitRunEvent: vi.fn(),
+}));
+
+import { executeReviewMode } from "../../src/orchestration/review.js";
+import { invokeAgent } from "../../src/agent/invoke.js";
+import { runValidationLoop } from "../../src/validation/runner.js";
+import { destroyContainer } from "../../src/container/runner.js";
+import { cleanupRun } from "../../src/container/cleanup.js";
+import { collectOutput } from "../../src/output/collector.js";
+import { Logger } from "../../src/logging/logger.js";
+
+function makePlan(overrides: Partial<RunPlan> = {}): RunPlan {
+  return {
+    runId: "forge-test-001",
+    task: "Add rate limiting",
+    workflow: {
+      name: "code",
+      description: "",
+      container: { image: "forgectl/code-node20", network: { mode: "open", allow: [] } },
+      input: { mode: "repo", mountPath: "/workspace" },
+      tools: [],
+      system: "",
+      validation: { steps: [], on_failure: "abandon" },
+      output: { mode: "git", path: "/workspace", collect: [] },
+      review: { enabled: true, system: "Review the code." },
+    },
+    agent: { type: "claude-code", model: "", maxTurns: 50, timeout: 300000, flags: [] },
+    container: {
+      image: "forgectl/code-node20",
+      network: { mode: "open", dockerNetwork: "bridge" },
+      resources: { memory: "4g", cpus: 2 },
+    },
+    input: { mode: "repo", sources: ["/tmp/repo"], mountPath: "/workspace", exclude: [] },
+    context: { system: "", files: [], inject: [] },
+    validation: { steps: [], onFailure: "abandon" },
+    output: { mode: "git", path: "/workspace", collect: [], hostDir: "/tmp/out" },
+    orchestration: {
+      mode: "review",
+      review: {
+        enabled: true,
+        system: "You are a code reviewer.",
+        maxRounds: 3,
+        agent: "claude-code",
+        model: "",
+      },
+    },
+    commit: {
+      message: { prefix: "[forge]", template: "{{task}}", includeTask: true },
+      author: { name: "forgectl", email: "forge@localhost" },
+      sign: false,
+    },
+    ...overrides,
+  } as RunPlan;
+}
+
+describe("executeReviewMode", () => {
+  let logger: Logger;
+
+  beforeEach(() => {
+    logger = new Logger(false);
+    vi.clearAllMocks();
+    // Reset default mock for implementer container
+    mocks.implementerContainer.getArchive.mockResolvedValue(Buffer.from("fake-tar"));
+    mocks.implementerContainer.putArchive.mockResolvedValue(undefined);
+  });
+
+  it("exits after first round when reviewer approves", async () => {
+    vi.mocked(invokeAgent)
+      // 1st call: implementer initial execution
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "done", stderr: "", durationMs: 1000 })
+      // 2nd call: reviewer says LGTM
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "Everything looks good.\n\nLGTM", stderr: "", durationMs: 500 });
+
+    const plan = makePlan();
+    const result = await executeReviewMode(plan, logger);
+
+    expect(result.success).toBe(true);
+    expect(result.review).toBeDefined();
+    expect(result.review!.approved).toBe(true);
+    expect(result.review!.approvedOnRound).toBe(1);
+    expect(result.review!.totalRounds).toBe(1);
+    expect(result.output).toBeDefined();
+    // invokeAgent called 2 times: implementer + reviewer
+    expect(vi.mocked(invokeAgent)).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-invokes implementer when reviewer finds issues, then approves", async () => {
+    vi.mocked(invokeAgent)
+      // 1st: implementer initial run
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "done", stderr: "", durationMs: 1000 })
+      // 2nd: reviewer round 1 — issues
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "1. Missing error handling\n2. No tests", stderr: "", durationMs: 500 })
+      // 3rd: implementer fix
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "fixed", stderr: "", durationMs: 1000 })
+      // 4th: reviewer round 2 — approved
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "LGTM", stderr: "", durationMs: 500 });
+
+    const plan = makePlan();
+    const result = await executeReviewMode(plan, logger);
+
+    expect(result.success).toBe(true);
+    expect(result.review!.approved).toBe(true);
+    expect(result.review!.approvedOnRound).toBe(2);
+    expect(result.review!.totalRounds).toBe(2);
+    // 4 invokeAgent calls: implementer + reviewer1 + fix + reviewer2
+    expect(vi.mocked(invokeAgent)).toHaveBeenCalledTimes(4);
+  });
+
+  it("stops after maxRounds and reports failure", async () => {
+    vi.mocked(invokeAgent)
+      // implementer initial run
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "done", stderr: "", durationMs: 1000 })
+      // reviewer round 1 — issues
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "1. Issue A", stderr: "", durationMs: 500 })
+      // implementer fix
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "fixed", stderr: "", durationMs: 1000 })
+      // reviewer round 2 — still issues
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "1. Issue B", stderr: "", durationMs: 500 });
+
+    const plan = makePlan({
+      orchestration: {
+        mode: "review",
+        review: { enabled: true, system: "Review.", maxRounds: 2, agent: "claude-code", model: "" },
+      },
+    });
+
+    const result = await executeReviewMode(plan, logger);
+
+    expect(result.success).toBe(false);
+    expect(result.review!.approved).toBe(false);
+    expect(result.review!.totalRounds).toBe(2);
+    expect(result.review!.approvedOnRound).toBeUndefined();
+    // Output is still collected since validation passed
+    expect(vi.mocked(collectOutput)).toHaveBeenCalled();
+  });
+
+  it("handles validation failure during fix cycle with abandon policy", async () => {
+    vi.mocked(invokeAgent)
+      // implementer initial run
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "done", stderr: "", durationMs: 1000 })
+      // reviewer round 1 — issues
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "1. Bug found", stderr: "", durationMs: 500 })
+      // implementer fix
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "tried to fix", stderr: "", durationMs: 1000 });
+
+    // Initial validation passes, re-validation after fix fails
+    vi.mocked(runValidationLoop)
+      .mockResolvedValueOnce({ passed: true, totalAttempts: 1, stepResults: [] })
+      .mockResolvedValueOnce({ passed: false, totalAttempts: 2, stepResults: [{ name: "test", passed: false, attempts: 2 }] });
+
+    const plan = makePlan({
+      validation: {
+        steps: [{ name: "test", command: "npm test", retries: 2, description: "Tests" }],
+        onFailure: "abandon",
+      },
+    });
+
+    const result = await executeReviewMode(plan, logger);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Validation failed during review fix cycle");
+    expect(result.review).toBeDefined();
+    expect(result.review!.approved).toBe(false);
+    // Output should NOT be collected since validation failed with abandon
+    expect(vi.mocked(collectOutput)).not.toHaveBeenCalled();
+  });
+
+  it("handles initial validation failure with abandon policy", async () => {
+    vi.mocked(invokeAgent)
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "done", stderr: "", durationMs: 1000 });
+
+    vi.mocked(runValidationLoop)
+      .mockResolvedValueOnce({ passed: false, totalAttempts: 3, stepResults: [{ name: "lint", passed: false, attempts: 3 }] });
+
+    const plan = makePlan({
+      validation: {
+        steps: [{ name: "lint", command: "npm run lint", retries: 3, description: "Lint" }],
+        onFailure: "abandon",
+      },
+    });
+
+    const result = await executeReviewMode(plan, logger);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Validation failed");
+    // Review loop should not even start
+    expect(result.review).toBeUndefined();
+  });
+
+  it("cleans up reviewer container even on errors", async () => {
+    vi.mocked(invokeAgent)
+      // implementer initial run
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "done", stderr: "", durationMs: 1000 })
+      // reviewer throws
+      .mockRejectedValueOnce(new Error("Agent crashed"));
+
+    const plan = makePlan();
+    const result = await executeReviewMode(plan, logger);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Agent crashed");
+    // cleanupRun should be called for both reviewer and implementer cleanup
+    expect(vi.mocked(cleanupRun)).toHaveBeenCalledTimes(2);
+  });
+
+  it("destroys reviewer container after each round", async () => {
+    vi.mocked(invokeAgent)
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "done", stderr: "", durationMs: 1000 })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "1. Issue", stderr: "", durationMs: 500 })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "fixed", stderr: "", durationMs: 1000 })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "LGTM", stderr: "", durationMs: 500 });
+
+    const plan = makePlan();
+    await executeReviewMode(plan, logger);
+
+    // destroyContainer called once per review round (2 rounds)
+    expect(vi.mocked(destroyContainer)).toHaveBeenCalledTimes(2);
+  });
+
+  it("snapshots workspace from implementer to reviewer container", async () => {
+    vi.mocked(invokeAgent)
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "done", stderr: "", durationMs: 1000 })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "LGTM", stderr: "", durationMs: 500 });
+
+    const plan = makePlan();
+    await executeReviewMode(plan, logger);
+
+    // getArchive called on implementer container
+    expect(mocks.implementerContainer.getArchive).toHaveBeenCalledWith({ path: "/workspace" });
+  });
+
+  it("returns review summary even when not approved but output collected", async () => {
+    vi.mocked(invokeAgent)
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "done", stderr: "", durationMs: 1000 })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "1. Critical issue", stderr: "", durationMs: 500 });
+
+    const plan = makePlan({
+      orchestration: {
+        mode: "review",
+        review: { enabled: true, system: "Review.", maxRounds: 1, agent: "claude-code", model: "" },
+      },
+    });
+
+    const result = await executeReviewMode(plan, logger);
+
+    expect(result.success).toBe(false);
+    expect(result.review!.totalRounds).toBe(1);
+    expect(result.review!.approved).toBe(false);
+    // Output still collected because validation passed
+    expect(result.output).toBeDefined();
+  });
+});

--- a/test/unit/review.test.ts
+++ b/test/unit/review.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseReviewResult,
+  buildReviewPrompt,
+  buildFixPrompt,
+} from "../../src/orchestration/review.js";
+import type { RunPlan } from "../../src/workflow/types.js";
+
+function makePlan(overrides: Partial<RunPlan> = {}): RunPlan {
+  return {
+    runId: "forge-test-001",
+    task: "Add rate limiting to the API",
+    workflow: {
+      name: "code",
+      description: "Code workflow",
+      container: { image: "forgectl/code-node20", network: { mode: "open", allow: [] } },
+      input: { mode: "repo", mountPath: "/workspace" },
+      tools: ["git", "node/npm"],
+      system: "You are an expert software engineer.",
+      validation: { steps: [], on_failure: "abandon" },
+      output: { mode: "git", path: "/workspace", collect: [] },
+      review: {
+        enabled: true,
+        system: "You are a senior code reviewer.",
+      },
+    },
+    agent: {
+      type: "claude-code",
+      model: "claude-sonnet-4-20250514",
+      maxTurns: 50,
+      timeout: 300000,
+      flags: [],
+    },
+    container: {
+      image: "forgectl/code-node20",
+      network: { mode: "open", dockerNetwork: "bridge" },
+      resources: { memory: "4g", cpus: 2 },
+    },
+    input: {
+      mode: "repo",
+      sources: ["/tmp/test-repo"],
+      mountPath: "/workspace",
+      exclude: ["node_modules"],
+    },
+    context: { system: "", files: [], inject: [] },
+    validation: { steps: [], onFailure: "abandon" },
+    output: {
+      mode: "git",
+      path: "/workspace",
+      collect: [],
+      hostDir: "/tmp/output",
+    },
+    orchestration: {
+      mode: "review",
+      review: {
+        enabled: true,
+        system: "You are a senior code reviewer. Check for bugs and security issues.",
+        maxRounds: 3,
+        agent: "claude-code",
+        model: "claude-sonnet-4-20250514",
+      },
+    },
+    commit: {
+      message: { prefix: "forge:", template: "{{task}}", includeTask: true },
+      author: { name: "forgectl", email: "forgectl@localhost" },
+      sign: false,
+    },
+    ...overrides,
+  } as RunPlan;
+}
+
+describe("parseReviewResult", () => {
+  it("detects LGTM at end of output", () => {
+    const result = parseReviewResult("Everything looks good.\n\nLGTM");
+    expect(result.approved).toBe(true);
+    expect(result.feedback).toBe("");
+  });
+
+  it("detects LGTM on its own line", () => {
+    const result = parseReviewResult("LGTM");
+    expect(result.approved).toBe(true);
+  });
+
+  it("detects LGTM case-insensitively", () => {
+    const result = parseReviewResult("lgtm");
+    expect(result.approved).toBe(true);
+  });
+
+  it("detects Lgtm mixed case", () => {
+    const result = parseReviewResult("Lgtm");
+    expect(result.approved).toBe(true);
+  });
+
+  it("detects APPROVED", () => {
+    const result = parseReviewResult("The code is well-written.\n\nAPPROVED");
+    expect(result.approved).toBe(true);
+    expect(result.feedback).toBe("");
+  });
+
+  it("detects Approved case-insensitively", () => {
+    const result = parseReviewResult("Approved");
+    expect(result.approved).toBe(true);
+  });
+
+  it("detects LGTM with surrounding text in last lines", () => {
+    const result = parseReviewResult("Reviewed the changes.\nAll checks pass.\nLGTM - ship it!");
+    expect(result.approved).toBe(true);
+  });
+
+  it("returns approved=false when issues are listed", () => {
+    const issues = `1. Missing error handling in /api/upload
+2. No rate limit tests
+3. Hardcoded timeout value`;
+    const result = parseReviewResult(issues);
+    expect(result.approved).toBe(false);
+    expect(result.feedback).toBe(issues);
+  });
+
+  it("returns full output as feedback when not approved", () => {
+    const output = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\nIssues found.";
+    const result = parseReviewResult(output);
+    expect(result.approved).toBe(false);
+    expect(result.feedback).toBe(output);
+  });
+
+  it("does not approve when LGTM appears early but issues are at the end", () => {
+    const output = "Initially LGTM but then:\n\n\n\n\n\n1. Found a security issue\n2. Missing validation";
+    const result = parseReviewResult(output);
+    expect(result.approved).toBe(false);
+  });
+
+  it("handles empty output", () => {
+    const result = parseReviewResult("");
+    expect(result.approved).toBe(false);
+    expect(result.feedback).toBe("");
+  });
+
+  it("handles output with only whitespace", () => {
+    const result = parseReviewResult("   \n\n   ");
+    expect(result.approved).toBe(false);
+  });
+
+  it("trims whitespace around output", () => {
+    const result = parseReviewResult("  \n  LGTM  \n  ");
+    expect(result.approved).toBe(true);
+  });
+
+  it("detects LGTM as word boundary (not partial match)", () => {
+    // "LGTM" should match as a word
+    const result = parseReviewResult("LGTM");
+    expect(result.approved).toBe(true);
+  });
+});
+
+describe("buildReviewPrompt", () => {
+  it("includes reviewer system prompt", () => {
+    const plan = makePlan();
+    const prompt = buildReviewPrompt(plan, 1);
+    expect(prompt).toContain("You are a senior code reviewer");
+  });
+
+  it("includes original task", () => {
+    const plan = makePlan();
+    const prompt = buildReviewPrompt(plan, 1);
+    expect(prompt).toContain("Add rate limiting to the API");
+    expect(prompt).toContain("--- Original Task ---");
+  });
+
+  it("includes round number", () => {
+    const plan = makePlan();
+    const prompt = buildReviewPrompt(plan, 2);
+    expect(prompt).toContain("review round 2");
+  });
+
+  it("includes git diff instruction for git output mode", () => {
+    const plan = makePlan();
+    const prompt = buildReviewPrompt(plan, 1);
+    expect(prompt).toContain("git diff HEAD~1");
+  });
+
+  it("includes file path instruction for files output mode", () => {
+    const plan = makePlan({
+      output: { mode: "files", path: "/output", collect: ["*"], hostDir: "/tmp/out" },
+    });
+    const prompt = buildReviewPrompt(plan, 1);
+    expect(prompt).toContain("/output");
+    expect(prompt).toContain("output files");
+  });
+
+  it("includes LGTM instruction", () => {
+    const plan = makePlan();
+    const prompt = buildReviewPrompt(plan, 1);
+    expect(prompt).toContain("LGTM");
+  });
+
+  it("includes instruction to list issues", () => {
+    const plan = makePlan();
+    const prompt = buildReviewPrompt(plan, 1);
+    expect(prompt).toContain("list them numbered");
+  });
+});
+
+describe("buildFixPrompt", () => {
+  it("includes round number", () => {
+    const prompt = buildFixPrompt("Some issue found", 1);
+    expect(prompt).toContain("round 1");
+  });
+
+  it("includes review feedback", () => {
+    const feedback = "1. Missing error handling\n2. No tests";
+    const prompt = buildFixPrompt(feedback, 2);
+    expect(prompt).toContain("Missing error handling");
+    expect(prompt).toContain("No tests");
+  });
+
+  it("includes REVIEW FEEDBACK header", () => {
+    const prompt = buildFixPrompt("issue", 1);
+    expect(prompt).toContain("REVIEW FEEDBACK");
+  });
+
+  it("includes fix instruction", () => {
+    const prompt = buildFixPrompt("issue", 1);
+    expect(prompt).toContain("Fix all issues listed above");
+  });
+
+  it("mentions reviewer will check again", () => {
+    const prompt = buildFixPrompt("issue", 1);
+    expect(prompt).toContain("reviewer will check again");
+  });
+});


### PR DESCRIPTION
## Summary
- Implement review mode orchestration: a two-agent loop where a reviewer examines the implementer's work and feeds issues back for iterative fixes
- Extract `prepareExecution()` from `executeSingleAgent()` as a shared helper to avoid code duplication between single and review modes
- Wire review mode into the dispatcher, update CLI output to show review status in header/summary/dry-run
- Add 35 new tests (26 unit tests for prompt building/result parsing, 9 mock-based integration tests for the review loop lifecycle)

## Test plan
- [x] All 178 existing + new unit tests pass (`FORGECTL_SKIP_DOCKER=true npm test`)
- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] `parseReviewResult` correctly detects LGTM/APPROVED in various formats
- [x] Review loop exits on approval, retries on issues, stops at maxRounds
- [x] Validation failures during fix cycles handled correctly
- [x] Reviewer container cleanup happens even on errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)