### PR TITLE
Add Codex OAuth session support

### DIFF
--- a/src/auth/codex.ts
+++ b/src/auth/codex.ts
@@ -1,9 +1,27 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { getCredential, setCredential } from "./store.js";
 
 const PROVIDER = "codex";
 
-export async function getCodexAuth(): Promise<string | null> {
-  return getCredential(PROVIDER, "api_key");
+export interface CodexAuth {
+  type: "api_key" | "oauth_session";
+  apiKey?: string;
+  sessionDir?: string;    // Path to ~/.codex (contains auth.json, config.toml)
+}
+
+export async function getCodexAuth(): Promise<CodexAuth | null> {
+  // Check for API key first
+  const apiKey = await getCredential(PROVIDER, "api_key");
+  if (apiKey) return { type: "api_key", apiKey };
+
+  // Check for OAuth session (codex login stores credentials in ~/.codex/)
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+  const codexHome = process.env.CODEX_HOME || join(home, ".codex");
+  const authJson = join(codexHome, "auth.json");
+  if (existsSync(authJson)) return { type: "oauth_session", sessionDir: codexHome };
+
+  return null;
 }
 
 export async function setCodexApiKey(key: string): Promise<void> {

--- a/src/auth/mount.ts
+++ b/src/auth/mount.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomBytes } from "node:crypto";
 import type { ClaudeAuth } from "./claude.js";
+import type { CodexAuth } from "./codex.js";
 
 export interface ContainerMounts {
   binds: string[];                   // Docker bind mount strings
@@ -33,16 +34,26 @@ export function prepareClaudeMounts(auth: ClaudeAuth, runId: string): ContainerM
   };
 }
 
-export function prepareCodexMounts(apiKey: string, runId: string): ContainerMounts {
+export function prepareCodexMounts(auth: CodexAuth, runId: string): ContainerMounts {
   const secretsDir = join(tmpdir(), `forgectl-secrets-${runId}-${randomBytes(4).toString("hex")}`);
   mkdirSync(secretsDir, { recursive: true, mode: 0o700 });
+  const binds: string[] = [];
+  const env: Record<string, string> = {};
 
-  const keyPath = join(secretsDir, "openai_api_key");
-  writeFileSync(keyPath, apiKey, { mode: 0o400 });
+  if (auth.type === "api_key" && auth.apiKey) {
+    const keyPath = join(secretsDir, "openai_api_key");
+    writeFileSync(keyPath, auth.apiKey, { mode: 0o400 });
+    binds.push(`${secretsDir}:/run/secrets:ro`);
+    env.OPENAI_API_KEY_FILE = "/run/secrets/openai_api_key";
+  } else if (auth.type === "oauth_session" && auth.sessionDir) {
+    // Mount the entire ~/.codex directory (contains auth.json + config.toml)
+    binds.push(`${auth.sessionDir}:/home/node/.codex:ro`);
+    env.CODEX_HOME = "/home/node/.codex";
+  }
 
   return {
-    binds: [`${secretsDir}:/run/secrets:ro`],
-    env: { OPENAI_API_KEY_FILE: "/run/secrets/openai_api_key" },
+    binds,
+    env,
     cleanup: () => { try { rmSync(secretsDir, { recursive: true, force: true }); } catch { /* ignore */ } },
   };
 }

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -41,6 +41,15 @@ export async function authCommand(action: string, provider?: string): Promise<vo
       await setClaudeApiKey(key);
       console.log(chalk.green("✔ Claude Code API key saved."));
     } else if (provider === "codex") {
+      // Check for existing OAuth session first
+      const { getCodexAuth } = await import("../auth/codex.js");
+      const existing = await getCodexAuth();
+      if (existing?.type === "oauth_session") {
+        console.log(chalk.green("✔ Found existing Codex OAuth session at ~/.codex/"));
+        console.log(chalk.gray("  (from 'codex login'). This will be used automatically."));
+        const override = await prompt("Add an API key anyway? (y/N): ");
+        if (override.toLowerCase() !== "y") return;
+      }
       const key = await prompt("Enter your OpenAI API key: ");
       await setCodexApiKey(key);
       console.log(chalk.green("✔ Codex (OpenAI) API key saved."));

--- a/src/orchestration/preflight.ts
+++ b/src/orchestration/preflight.ts
@@ -35,7 +35,7 @@ export async function runPreflightChecks(plan: RunPlan, logger: Logger): Promise
   } else if (plan.agent.type === "codex") {
     const auth = await getCodexAuth();
     if (!auth) {
-      errors.push("No Codex credentials found. Run: forgectl auth add codex");
+      errors.push("No Codex credentials found. Run: codex login (OAuth) or forgectl auth add codex (API key)");
     }
   }
 

--- a/src/orchestration/review.ts
+++ b/src/orchestration/review.ts
@@ -102,12 +102,17 @@ async function prepareReviewerCredentials(
     }
     agentEnv.push("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1");
   } else {
-    const apiKey = await getCodexAuth();
-    if (!apiKey) throw new Error("No Codex credentials configured for reviewer");
-    const mounts = prepareCodexMounts(apiKey, `${runId}-reviewer-${round}`);
+    const auth = await getCodexAuth();
+    if (!auth) throw new Error("No Codex credentials configured for reviewer. Run: codex login (OAuth) or forgectl auth add codex (API key)");
+    const mounts = prepareCodexMounts(auth, `${runId}-reviewer-${round}`);
     binds.push(...mounts.binds);
     cleanup.secretCleanups.push(mounts.cleanup);
-    agentEnv.push(`OPENAI_API_KEY=${apiKey}`);
+    if (auth.type === "api_key" && auth.apiKey) {
+      agentEnv.push(`OPENAI_API_KEY=${auth.apiKey}`);
+    }
+    if (mounts.env.CODEX_HOME) {
+      agentEnv.push(`CODEX_HOME=${mounts.env.CODEX_HOME}`);
+    }
   }
 
   return { binds, agentEnv };

--- a/src/orchestration/single.ts
+++ b/src/orchestration/single.ts
@@ -80,12 +80,17 @@ export async function prepareExecution(
     }
     agentEnv.push("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1");
   } else {
-    const apiKey = await getCodexAuth();
-    if (!apiKey) throw new Error("No Codex credentials configured");
-    const mounts = prepareCodexMounts(apiKey, plan.runId);
+    const auth = await getCodexAuth();
+    if (!auth) throw new Error("No Codex credentials configured. Run: codex login (OAuth) or forgectl auth add codex (API key)");
+    const mounts = prepareCodexMounts(auth, plan.runId);
     binds.push(...mounts.binds);
     cleanup.secretCleanups.push(mounts.cleanup);
-    agentEnv.push(`OPENAI_API_KEY=${apiKey}`);
+    if (auth.type === "api_key" && auth.apiKey) {
+      agentEnv.push(`OPENAI_API_KEY=${auth.apiKey}`);
+    }
+    if (mounts.env.CODEX_HOME) {
+      agentEnv.push(`CODEX_HOME=${mounts.env.CODEX_HOME}`);
+    }
   }
 
   // 4. Create network (only for allowlist mode)


### PR DESCRIPTION
## Summary
- Add `CodexAuth` union type (mirrors existing `ClaudeAuth`) supporting both `api_key` and `oauth_session`
- `getCodexAuth()` now detects OAuth credentials from `codex login` at `~/.codex/auth.json` (or `$CODEX_HOME`)
- `prepareCodexMounts()` accepts `CodexAuth` instead of raw string — mounts `~/.codex:ro` and sets `CODEX_HOME` for OAuth sessions
- Update `single.ts` and `review.ts` to handle both auth types when building agent env vars
- Update preflight error message with actionable OAuth hint
- Update `auth add codex` CLI flow to detect and report existing OAuth sessions before prompting for API key

## Test plan
- [x] `npm run typecheck` passes clean
- [x] All 178 tests pass (`FORGECTL_SKIP_DOCKER=true npm test`)
- [x] No new tests needed — detection logic mirrors existing `ClaudeAuth` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)